### PR TITLE
Remove replica counts from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - submission-history-database
     restart: always
     deploy:
-      replicas: 3
+      replicas: 1
       restart_policy:
         condition: on-failure
   submission-history-database:
@@ -132,7 +132,7 @@ services:
     networks:
       microservice:
     deploy:
-      replicas: 5
+      replicas: 1
       restart_policy:
         condition: on-failure
   # Defines the Sessions microservice


### PR DESCRIPTION
These break docker-compose and will be manually added on the demo swarm